### PR TITLE
FEATURE: update `gpkg`

### DIFF
--- a/scripts/gpkg
+++ b/scripts/gpkg
@@ -21,7 +21,6 @@ def pacman_deps_wrapper [
     | rename package version
 }
 
-
 def cargo_deps [] {
     print "cargo install  --list"
 
@@ -33,7 +32,6 @@ def cargo_deps [] {
     | rename package version
 }
 
-
 def pip_deps [] {
     print "pip freeze"
 
@@ -42,7 +40,6 @@ def pip_deps [] {
     | split column "=="
     | rename package version
 }
-
 
 def pipx_deps [] {
     print "pipx list"
@@ -56,7 +53,6 @@ def pipx_deps [] {
     | split column " "
     | rename package version python
 }
-
 
 def main [
     output: string = "~/pkgs.toml"

--- a/scripts/gpkg
+++ b/scripts/gpkg
@@ -26,7 +26,7 @@ def cargo_deps [] {
 
     cargo install --list
     | lines
-    | find -rm ":\$"
+    | find --multiline --regex ":\$"
     | str replace ":$" ""
     | split column " v"
     | rename package version

--- a/scripts/gpkg
+++ b/scripts/gpkg
@@ -74,5 +74,5 @@ def main [
     }
 
     print $"Saving the system dependencies to ($output | path expand)"
-    $x | save ($output | path expand)
+    $x | save --force ($output | path expand)
 }

--- a/scripts/gpkg
+++ b/scripts/gpkg
@@ -15,46 +15,46 @@ def pacman_deps_wrapper [
 ] {
     print $"pacman ($flag)"
 
-    pacman $flag |
-        lines |
-        split column " " |
-        rename package version
+    pacman $flag
+    | lines
+    | split column " "
+    | rename package version
 }
 
 
 def cargo_deps [] {
     print "cargo install  --list"
 
-    cargo install --list |
-        lines |
-        find -rm ":\$" |
-        str replace ":$" "" |
-        split column " v" |
-        rename package version
+    cargo install --list
+    | lines
+    | find -rm ":\$"
+    | str replace ":$" ""
+    | split column " v"
+    | rename package version
 }
 
 
 def pip_deps [] {
     print "pip freeze"
 
-    pip freeze  |
-        lines |
-        split column "==" |
-        rename package version
+    pip freeze
+    | lines
+    | split column "=="
+    | rename package version
 }
 
 
 def pipx_deps [] {
     print "pipx list"
 
-    pipx list |
-        lines |
-        find ", installed" |
-        str trim |
-        str replace "package " "" |
-        str replace ", installed using Python" "" |
-        split column " " |
-        rename package version python
+    pipx list
+    | lines
+    | find ", installed"
+    | str trim
+    | str replace "package " ""
+    | str replace ", installed using Python" ""
+    | split column " "
+    | rename package version python
 }
 
 

--- a/scripts/gpkg
+++ b/scripts/gpkg
@@ -58,23 +58,18 @@ def main [
     output: string = "~/pkgs.toml"
 ] {
     let x = {
-        pkgs: {
-            pacman:
-                {
-                    all: (pacman_deps_wrapper --flag "-Q"),
-                    explicit: (pacman_deps_wrapper --flag "-Qe"),
-                    native: (pacman_deps_wrapper --flag "-Qen"),
-                    foreign: (pacman_deps_wrapper --flag "-Qem")
-                }
-            rust:
-                {
-                    cargo: (cargo_deps)
-                }
-            python:
-                {
-                    pip: (pip_deps),
-                    pipx: (pipx_deps)
-                }
+        pacman: {
+            all: (pacman_deps_wrapper --flag "-Q"),
+            explicit: (pacman_deps_wrapper --flag "-Qe"),
+            native: (pacman_deps_wrapper --flag "-Qen"),
+            foreign: (pacman_deps_wrapper --flag "-Qem")
+        }
+        rust: {
+            cargo: (cargo_deps)
+        }
+        python: {
+            pip: (pip_deps),
+            pipx: (pipx_deps)
         }
     }
 

--- a/scripts/gpkg
+++ b/scripts/gpkg
@@ -10,10 +10,15 @@
 #*              ATXR:    https://github.com/atxr    atxr#6214    AF97503EDC65A06845114630F00A52147514670B
 #*
 
+def pretty-cmd [] {
+    let cmd = $in
+    $"(ansi -e {fg: default attr: di})($cmd)(ansi reset)"
+}
+
 def pacman_deps_wrapper [
     --flag (-f): string
 ] {
-    print $"pacman ($flag)"
+    print $"running ($'pacman ($flag)' | pretty-cmd)"
 
     pacman $flag
     | lines
@@ -22,7 +27,7 @@ def pacman_deps_wrapper [
 }
 
 def cargo_deps [] {
-    print "cargo install  --list"
+    print $"running ('cargo install  --list' | pretty-cmd)"
 
     cargo install --list
     | lines
@@ -33,7 +38,7 @@ def cargo_deps [] {
 }
 
 def pip_deps [] {
-    print "pip freeze"
+    print $"running ('pip freeze' | pretty-cmd)"
 
     pip freeze
     | lines
@@ -42,7 +47,7 @@ def pip_deps [] {
 }
 
 def pipx_deps [] {
-    print "pipx list"
+    print $"running ('pipx list' | pretty-cmd)"
 
     pipx list
     | lines

--- a/scripts/gpkg
+++ b/scripts/gpkg
@@ -10,6 +10,8 @@
 #*              ATXR:    https://github.com/atxr    atxr#6214    AF97503EDC65A06845114630F00A52147514670B
 #*
 
+use std 'log info'
+
 def pretty-cmd [] {
     let cmd = $in
     $"(ansi -e {fg: default attr: di})($cmd)(ansi reset)"
@@ -18,7 +20,7 @@ def pretty-cmd [] {
 def pacman_deps_wrapper [
     --flag (-f): string
 ] {
-    print $"running ($'pacman ($flag)' | pretty-cmd)"
+    log info $"running ($'pacman ($flag)' | pretty-cmd)"
 
     pacman $flag
     | lines
@@ -27,7 +29,7 @@ def pacman_deps_wrapper [
 }
 
 def cargo_deps [] {
-    print $"running ('cargo install  --list' | pretty-cmd)"
+    log info $"running ('cargo install  --list' | pretty-cmd)"
 
     cargo install --list
     | lines
@@ -38,7 +40,7 @@ def cargo_deps [] {
 }
 
 def pip_deps [] {
-    print $"running ('pip freeze' | pretty-cmd)"
+    log info $"running ('pip freeze' | pretty-cmd)"
 
     pip freeze
     | lines
@@ -47,7 +49,7 @@ def pip_deps [] {
 }
 
 def pipx_deps [] {
-    print $"running ('pipx list' | pretty-cmd)"
+    log info $"running ('pipx list' | pretty-cmd)"
 
     pipx list
     | lines

--- a/scripts/gpkg
+++ b/scripts/gpkg
@@ -13,7 +13,7 @@
 def pacman_deps_wrapper [
     --flag (-f): string
 ] {
-    echo $"pacman ($flag)"
+    print $"pacman ($flag)"
 
     pacman $flag |
         lines |
@@ -23,7 +23,7 @@ def pacman_deps_wrapper [
 
 
 def cargo_deps [] {
-    echo "cargo install  --list"
+    print "cargo install  --list"
 
     cargo install --list |
         lines |
@@ -35,7 +35,7 @@ def cargo_deps [] {
 
 
 def pip_deps [] {
-    echo "pip freeze"
+    print "pip freeze"
 
     pip freeze  |
         lines |
@@ -45,7 +45,7 @@ def pip_deps [] {
 
 
 def pipx_deps [] {
-    echo "pipx list"
+    print "pipx list"
 
     pipx list |
         lines |


### PR DESCRIPTION
this PR updates the `gpkg` script
- make it `0.79` compatible
- move the `|` to the start of the lines
- fix the `find -rm` call
- remove the extra `pkg` depth level from the final data
- add `--force` to `save`
- use `pretty-cmd` in `std log info` for prettier output